### PR TITLE
update bower name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "array polyfill",
+  "name": "array-polyfill",
   "main": "array-polyfill.js",
   "version": "0.2.1",
   "homepage": "https://github.com/zhongdeliu/array-polyfill",


### PR DESCRIPTION
so bower doesn't complain with

    bower array-polyfill#*    invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes